### PR TITLE
Renaming user id to host

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,6 @@ class Event < ApplicationRecord
   has_many :potential_attendees
   has_many :users, through: :potential_attendees
 
-  # validates :user, :name, :photo, :people_needed, :location, :start_time, :end_time, presence: true
-  # validates_numericality_of :people_needed, greater_than: 0
+  validates :user, :name, :photo, :people_needed, :location, :start_time, :end_time, presence: true
+  validates_numericality_of :people_needed, greater_than: 0
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,8 +1,8 @@
 class Event < ApplicationRecord
-  belongs_to :user
+  belongs_to :host, class_name: "User"
   has_many :potential_attendees
   has_many :users, through: :potential_attendees
 
-  validates :user, :name, :photo, :people_needed, :location, :start_time, :end_time, presence: true
+  validates :host, :name, :photo, :people_needed, :location, :start_time, :end_time, presence: true
   validates_numericality_of :people_needed, greater_than: 0
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,7 +1,8 @@
 class Event < ApplicationRecord
   belongs_to :user
-  has_many :events
+  has_many :potential_attendees
+  has_many :users, through: :potential_attendees
 
-  validates :user, :name, :photo, :people_needed, :location, :start_time, :end_time, presence: true
-  validates_numericality_of :people_needed, greater_than: 0
+  # validates :user, :name, :photo, :people_needed, :location, :start_time, :end_time, presence: true
+  # validates_numericality_of :people_needed, greater_than: 0
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :hosted_events, class_name: "Event"
+  has_many :hosted_events, class_name: "Event", foreign_key: :host_id
 
   def full_name
     "#{first_name} #{last_name}" if first_name && last_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_many :hosted_events, class_name: "Event"
 
   def full_name
     "#{first_name} #{last_name}" if first_name && last_name

--- a/db/migrate/20190715125316_create_events.rb
+++ b/db/migrate/20190715125316_create_events.rb
@@ -6,9 +6,9 @@ class CreateEvents < ActiveRecord::Migration[5.2]
       t.integer :people_needed
       t.date :date
       t.string :photo
-      t.references :user, foreign_key: true
 
       t.timestamps
     end
+    add_reference :events, :host, foreign_key: { to_table: :users }
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,12 +20,12 @@ ActiveRecord::Schema.define(version: 2019_07_15_151626) do
     t.text "description"
     t.integer "people_needed"
     t.string "photo"
-    t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "host_id"
     t.datetime "start_time", null: false
     t.datetime "end_time", null: false
-    t.index ["user_id"], name: "index_events_on_user_id"
+    t.index ["host_id"], name: "index_events_on_host_id"
   end
 
   create_table "potential_attendees", force: :cascade do |t|
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 2019_07_15_151626) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "events", "users"
+  add_foreign_key "events", "users", column: "host_id"
   add_foreign_key "potential_attendees", "events"
   add_foreign_key "potential_attendees", "users"
 end


### PR DESCRIPTION
These changes allow us to access the creator or owner of an event using #host. for example `event_name.host` would return the User that created the event, while `event_name.users` will return all potential attendees of the event.

@PaulinaGernandt @lille3lsa @thomyturner Please make sure you take heed of these changes. 
Also, make sure to run
`rails db:drop
rails db:create
rails db:migrate` as I couldn't do this in a new migration